### PR TITLE
Add the concept of an 'active' model: select which model is used by default.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,6 +68,7 @@ application.
   user/installation
   user/tutorial
   user/deployment
+  user/upgrading
   user/web-service
   user/R
   user/julia

--- a/docs/user/upgrading.rst
+++ b/docs/user/upgrading.rst
@@ -1,0 +1,39 @@
+.. _upgrading:
+
+=========
+Upgrading
+=========
+
+.. contents::
+   :local:
+
+
+Changes between Palladium versions may require upgrading the model
+database or similar.  These upgrades are handled automatically by the
+``pld-upgrade`` script.  Before running the script, make sure you've
+set the ``PALLADIUM_CONFIG`` environment variable, then simply run:
+
+.. code-block:: bash
+
+  pld-upgrade
+
+In some rare situations, it may be necessary to run the upgrade steps
+of specific versions only.  ``pld-upgrade`` supports passing
+``--from`` and ``--to`` options for that purpose.  As an example, if
+you only want to run the upgrade steps between version ``0.9`` and
+``1.0``, this is how you'd invoke ``pld-upgrade``:
+
+.. code-block:: bash
+
+  pld-upgrade --from=0.9.1 --to=1.0
+
+Upgrading the Database persister from version 0.9.1 to 1.0
+==========================================================
+
+Users of :class:`palladium.persistence.Database` that are upgrading
+from version 0.9.1 to a more recent version (maybe 1.0) are required
+to invoke pld-upgrade with an explicit ``--from`` version like so:
+
+.. code-block:: bash
+
+  pld-upgrade --from=0.9.1

--- a/palladium/eval.py
+++ b/palladium/eval.py
@@ -57,7 +57,10 @@ Options:
 
 @args_from_config
 def list(model_persister):
-    pprint(model_persister.list())
+    print("Models:")
+    pprint(model_persister.list_models())
+    print("Properties:")
+    pprint(model_persister.list_properties())
 
 
 def list_cmd(argv=sys.argv[1:]):  # pragma: no cover

--- a/palladium/tests/__init__.py
+++ b/palladium/tests/__init__.py
@@ -56,6 +56,7 @@ def run_smoke_tests_with_config(config_fname, run=None, raise_errors=True,
 
     with patch.dict('os.environ', {'PALLADIUM_CONFIG': config_fname}):
         from palladium.fit import fit
+        from palladium.fit import activate
         from palladium.fit import grid_search
         from palladium.eval import test
         from palladium.util import initialize_config
@@ -64,7 +65,7 @@ def run_smoke_tests_with_config(config_fname, run=None, raise_errors=True,
 
         with change_cwd(os.path.dirname(config_fname)):
             initialize_config(__mode__='fit')
-            for func in (fit, grid_search, test, predict):
+            for func in (fit, activate, grid_search, test, predict):
                 if run and func.__name__ not in run:
                     continue
                 try:

--- a/palladium/tests/test_eval.py
+++ b/palladium/tests/test_eval.py
@@ -1,4 +1,5 @@
 from unittest.mock import Mock
+from unittest.mock import call
 from unittest.mock import patch
 
 import pytest
@@ -42,7 +43,9 @@ class TestList:
 
     def test(self, list):
         model_persister = Mock()
-        model_persister.list.return_value = [{1: 2}]
+        model_persister.list_models.return_value = [{1: 2}]
+        model_persister.list_properties.return_value = {5: 6}
         with patch('palladium.eval.pprint') as pprint:
             list(model_persister)
-        pprint.assert_called_with([{1: 2}])
+        assert pprint.mock_calls[0] == call([{1: 2}])
+        assert pprint.mock_calls[1] == call({5: 6})

--- a/palladium/tests/test_fit.py
+++ b/palladium/tests/test_fit.py
@@ -32,6 +32,8 @@ class TestFit:
         dataset_loader_train.assert_called_with()
         model.fit.assert_called_with(X, y)
         model_persister.write.assert_called_with(model)
+        model_persister.activate.assert_called_with(
+            model_persister.write.return_value)
 
     def test_no_persist(self, fit):
         model, dataset_loader_train, model_persister = Mock(), Mock(), Mock()
@@ -155,6 +157,18 @@ class TestFit:
                 persist_if_better_than=0.9,
                 )
 
+    def test_activate_no_persist(self, fit, dataset_loader):
+        model, model_persister = Mock(), Mock()
+
+        result = fit(
+            dataset_loader_train=dataset_loader,
+            model=model,
+            model_persister=model_persister,
+            persist=False,
+            )
+        assert result is model
+        model_persister.activate.call_count == 0
+
     def test_timestamp(self, fit, dataset_loader):
         model, model_persister = Mock(), Mock()
 
@@ -175,6 +189,14 @@ class TestFit:
         timestamp = parse(model.__metadata__['train_timestamp'])
         assert before_fit < timestamp < after_fit
         model_persister.write.assert_called_with(model)
+
+
+def test_activate():
+    from palladium.fit import activate
+
+    persister = Mock()
+    activate(persister, 2)
+    persister.activate.assert_called_with(2)
 
 
 class TestGridSearch:

--- a/palladium/tests/test_util.py
+++ b/palladium/tests/test_util.py
@@ -345,6 +345,29 @@ class TestRruleThread:
         assert rr.between.call_count > 1
 
 
+class TestUpgrade:
+    @pytest.fixture
+    def upgrade(self):
+        from palladium.util import upgrade
+        return upgrade
+
+    def test_no_args(self, upgrade):
+        persister = Mock()
+        upgrade(persister)
+        persister.upgrade.assert_called_with(from_version=None)
+
+    def test_from_version(self, upgrade):
+        persister = Mock()
+        upgrade(persister, from_version='0.1')
+        persister.upgrade.assert_called_with(from_version='0.1')
+
+    def test_from_version_and_to_version(self, upgrade):
+        persister = Mock()
+        upgrade(persister, from_version='0.1', to_version='0.2')
+        persister.upgrade.assert_called_with(from_version='0.1',
+                                             to_version='0.2')
+
+
 def dec1(func):
     def inner(a, b):
         """dec1"""

--- a/palladium/util.py
+++ b/palladium/util.py
@@ -297,6 +297,36 @@ Options:
     print(__version__)
 
 
+@args_from_config
+def upgrade(model_persister, from_version=None, to_version=None):
+    kwargs = {'from_version': from_version}
+    if to_version is not None:
+        kwargs['to_version'] = to_version
+    model_persister.upgrade(**kwargs)
+
+
+def upgrade_cmd(argv=sys.argv[1:]):  # pragma: no cover
+    __doc__ = """
+Upgrade the database to the latest version.
+
+Usage:
+  pld-ugprade [options]
+
+Options:
+
+  --from=<v>               Upgrade from a specific version, overriding
+                           the version stored in the database.
+
+  --to=<v>                 Upgrade to a specific version instead of the
+                           latest version ({version}).
+
+  -h --help                Show this screen.
+""".format(version=__version__)
+    arguments = docopt(__doc__, argv=argv)
+    initialize_config(__mode__='fit')
+    upgrade(from_version=arguments['--from'], to_version=arguments['--to'])
+
+
 class PluggableDecorator:
     def __init__(self, decorator_config_name):
         self.decorator_config_name = decorator_config_name

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '0.10.dev1'
+version = '1.0.dev1'
 
 install_requires = [
     'docopt',
@@ -62,11 +62,13 @@ setup(name='palladium',
           },
       entry_points={
           'console_scripts': [
+              'pld-activate = palladium.fit:activate_cmd',
               'pld-devserver = palladium.server:devserver_cmd',
               'pld-fit = palladium.fit:fit_cmd',
               'pld-grid-search = palladium.fit:grid_search_cmd',
               'pld-list = palladium.eval:list_cmd',
               'pld-test = palladium.eval:test_cmd',
+              'pld-upgrade = palladium.util:upgrade_cmd',
               'pld-version = palladium.util:version_cmd',
               ],
           'pytest11': [


### PR DESCRIPTION
Requires upgrading the model persistence databases, and thus a new pld-upgrade.

NB: When upgrading between development versions, it might be necessary to explicitly override the `--to` version with pld-upgrade.  The upgrade steps are registered for version 1.0, but the current version is 1.0.dev1.  Therefore it's necessary to set `--to=1.0` or else the upgrade step won't be performed, because 1.0 isn't between 0.9.1 and 1.0.dev1.