### PR TITLE
Add a pluggable decorator around palladium.dataset.SQL

### DIFF
--- a/palladium/cache.py
+++ b/palladium/cache.py
@@ -60,6 +60,21 @@ class diskcache(abstractcache):
     you to purge existing cached values, then those cache files are
     found in the location defined in :attr:`filename_tmpl`.
     """
+    def __init__(self, *args, filename_tmpl=None, **kwargs):
+        """
+        :param str filename_tmpl:
+          The filename template that I will use to store cache files,
+          e.g. ``{}``.
+        """.format(diskcache.filename_tmpl)
+        super().__init__(*args, **kwargs)
+        if filename_tmpl is not None:
+            if '{key}' not in filename_tmpl:
+                raise ValueError(
+                    "Your filename_tmpl must have a {key} placeholder,"
+                    "e.g., cache-{key}.pickle."
+                    )
+            self.filename_tmpl = filename_tmpl
+
     #: Where to persist cached values
     filename_tmpl = '/tmp/cache-{module}.{func}-{key}.pickle'
 
@@ -105,3 +120,9 @@ class picklediskcache(diskcache):
     def dump(self, value, filename):
         with open(filename, 'wb') as f:
             return pickle.dump(value, f, -1)
+
+
+def compute_key_attrs(attrs):
+    def compute_key(self, *args, **kwargs):
+        return tuple(getattr(self, attr) for attr in attrs)
+    return compute_key

--- a/palladium/dataset.py
+++ b/palladium/dataset.py
@@ -92,6 +92,7 @@ class SQL(DatasetLoader):
         self.ndarray = ndarray
         self.kwargs = kwargs
 
+    @PluggableDecorator('load_data_decorators')
     def __call__(self):
         """See :meth:`palladium.interfaces.DatasetLoader.__call__`.
         """

--- a/palladium/tests/test_cache.py
+++ b/palladium/tests/test_cache.py
@@ -1,3 +1,4 @@
+from unittest.mock import Mock
 from random import random
 
 import pandas
@@ -61,9 +62,39 @@ class TestDiskCache:
                 squareit(3).squeeze()) == (4, 9, 9)
         assert called == [2, 3, 3]
 
+    def test_it_filename(self, diskcache, tmpdir):
+        called = []
+
+        @diskcache(filename_tmpl=str(tmpdir.join('filename-{key}')))
+        def squareit(x):
+            called.append(x)
+            return pandas.DataFrame([x ** 2])
+
+        assert len(tmpdir.listdir()) == 0
+        assert (squareit(2).squeeze(),
+                squareit(3).squeeze(),
+                squareit(3).squeeze()) == (4, 9, 9)
+        assert len(tmpdir.listdir()) > 0
+        assert called == [2, 3]
+
+    def test_it_bad_filename(self, diskcache):
+        with pytest.raises(ValueError):
+            diskcache(filename_tmpl='string-without-key')
+
 
 class TestPickleDiskCache(TestDiskCache):
     @pytest.fixture
     def diskcache(self):
         from palladium.cache import picklediskcache
         return picklediskcache
+
+
+class TestComputeKeyAttrs:
+    @pytest.fixture
+    def compute_key_attrs(self):
+        from palladium.cache import compute_key_attrs
+        return compute_key_attrs
+
+    def test_it(self, compute_key_attrs):
+        compute_key = compute_key_attrs(['one', 'two'])
+        compute_key(Mock(one=1, two=2, three=3)) == (1, 2)


### PR DESCRIPTION
This allows me to do:

```
    'load_data_decorators': [
        {
            '__factory__': 'palladium.cache.diskcache',
            'filename_tmpl': 'cache/dataset-{key}',
            'compute_key': {
                '__factory__': 'palladium.cache.compute_key_attrs',
                'attrs': ['engine', 'sql', 'target_column'],
            },
        },
    ],
```

Probably want to add a mention of this in the docs?

Supersedes #19