### PR TITLE
Add a pluggable decorators for DatasetLoader

### DIFF
--- a/palladium/cache.py
+++ b/palladium/cache.py
@@ -60,6 +60,21 @@ class diskcache(abstractcache):
     you to purge existing cached values, then those cache files are
     found in the location defined in :attr:`filename_tmpl`.
     """
+    def __init__(self, *args, filename_tmpl=None, **kwargs):
+        """
+        :param str filename_tmpl:
+          The filename template that I will use to store cache files,
+          e.g. ``{}``.
+        """.format(diskcache.filename_tmpl)
+        super().__init__(*args, **kwargs)
+        if filename_tmpl is not None:
+            if '{key}' not in filename_tmpl:
+                raise ValueError(
+                    "Your filename_tmpl must have a {key} placeholder,"
+                    "e.g., cache-{key}.pickle."
+                    )
+            self.filename_tmpl = filename_tmpl
+
     #: Where to persist cached values
     filename_tmpl = '/tmp/cache-{module}.{func}-{key}.pickle'
 
@@ -105,3 +120,9 @@ class picklediskcache(diskcache):
     def dump(self, value, filename):
         with open(filename, 'wb') as f:
             return pickle.dump(value, f, -1)
+
+
+def compute_key_attrs(attrs):
+    def compute_key(self, *args, **kwargs):
+        return tuple(getattr(self, attr) for attr in attrs)
+    return compute_key

--- a/palladium/interfaces.py
+++ b/palladium/interfaces.py
@@ -7,6 +7,7 @@ from abc import ABCMeta
 from sklearn.base import BaseEstimator
 
 from . import __version__
+from .util import PluggableDecorator
 
 
 def annotate(obj, metadata=None):
@@ -17,7 +18,13 @@ def annotate(obj, metadata=None):
     return obj.__metadata__
 
 
-class DatasetLoader(metaclass=ABCMeta):
+class DatasetLoaderMeta(ABCMeta):
+    def __init__(cls, name, bases, attrs, **kwargs):
+        super().__init__(name, bases, attrs, **kwargs)
+        cls.__call__ = PluggableDecorator('load_data_decorators')(cls.__call__)
+
+
+class DatasetLoader(metaclass=DatasetLoaderMeta):
     """A :class:`~palladium.interfaces.DatasetLoader` is responsible for
     loading datasets for use in training and evaluation.
     """

--- a/palladium/tests/test_cache.py
+++ b/palladium/tests/test_cache.py
@@ -1,3 +1,4 @@
+from unittest.mock import Mock
 from random import random
 
 import pandas
@@ -61,9 +62,39 @@ class TestDiskCache:
                 squareit(3).squeeze()) == (4, 9, 9)
         assert called == [2, 3, 3]
 
+    def test_it_filename(self, diskcache, tmpdir):
+        called = []
+
+        @diskcache(filename_tmpl=str(tmpdir.join('filename-{key}')))
+        def squareit(x):
+            called.append(x)
+            return pandas.DataFrame([x ** 2])
+
+        assert len(tmpdir.listdir()) == 0
+        assert (squareit(2).squeeze(),
+                squareit(3).squeeze(),
+                squareit(3).squeeze()) == (4, 9, 9)
+        assert len(tmpdir.listdir()) > 0
+        assert called == [2, 3]
+
+    def test_it_bad_filename(self, diskcache):
+        with pytest.raises(ValueError):
+            diskcache(filename_tmpl='string-without-key')
+
 
 class TestPickleDiskCache(TestDiskCache):
     @pytest.fixture
     def diskcache(self):
         from palladium.cache import picklediskcache
         return picklediskcache
+
+
+class TestComputeKeyAttrs:
+    @pytest.fixture
+    def compute_key_attrs(self):
+        from palladium.cache import compute_key_attrs
+        return compute_key_attrs
+
+    def test_it(self, compute_key_attrs):
+        compute_key = compute_key_attrs(['one', 'two'])
+        compute_key(Mock(one=1, two=2, three=3)) == (1, 2)

--- a/palladium/tests/test_interfaces.py
+++ b/palladium/tests/test_interfaces.py
@@ -22,6 +22,33 @@ class TestAnnotate:
         assert model.__metadata__['one'] == '11'
 
 
+def load_data_decorator(func):
+    def inner(self):
+        X, y = func(self)
+        return self.name + X, self.name + y
+    return inner
+
+
+class TestDatasetLoader:
+    @pytest.fixture
+    def DatasetLoader(self):
+        from palladium.interfaces import DatasetLoader
+        return DatasetLoader
+
+    def test_call_decorator(self, DatasetLoader, config):
+        config['load_data_decorators'] = [
+            'palladium.tests.test_interfaces.load_data_decorator'
+            ]
+
+        class MyDatasetLoader(DatasetLoader):
+            name = 'hey'
+
+            def __call__(self):
+                return 'X', 'y'
+
+        assert MyDatasetLoader()() == ('heyX', 'heyy')
+
+
 class TestPredictError:
     @pytest.fixture
     def PredictError(self):


### PR DESCRIPTION
This allows me to do:

```python
    'load_data_decorators': [
        {
            '__factory__': 'palladium.cache.diskcache',
            'filename_tmpl': 'cache/dataset-{key}',
            'compute_key': {
                '__factory__': 'palladium.cache.compute_key_attrs',
                'attrs': ['engine', 'sql', 'target_column'],
            },
        },
    ],
```

A variant of #20 that doesn't require each `DatasetLoader.__call__` method be decorated individually.  I like this one more, but it comes at a cost of some 'magic'.

Probably want to add a mention of this in the docs.

Supersedes #19 and #20