### PR TITLE
Allow for nested lists in the config

### DIFF
--- a/palladium/tests/test_util.py
+++ b/palladium/tests/test_util.py
@@ -62,17 +62,18 @@ class TestInitializeConfigImpl:
         return _initialize_config
 
     def test_initialize_config(self, _initialize_config):
+        dummy = 'palladium.tests.test_util.MyDummyComponent'
         config = {
             'mycomponent': {
-                '__factory__': 'palladium.tests.test_util.MyDummyComponent',
+                '__factory__': dummy,
                 'arg1': 3,
                 'arg2': {'no': 'factory'},
                 'subcomponent': {
-                    '__factory__': 'palladium.tests.test_util.MyDummyComponent',
+                    '__factory__': dummy,
                     'arg1': {
                         'subsubcomponent': {
                             '__factory__':
-                            'palladium.tests.test_util.MyDummyComponent',
+                            dummy,
                             'arg1': 'wobwob',
                             'arg2': 9,
                             },
@@ -81,16 +82,19 @@ class TestInitializeConfigImpl:
                     },
                 },
             'mylistofcomponents': [{
-                '__factory__': 'palladium.tests.test_util.MyDummyComponent',
+                '__factory__': dummy,
                 'arg1': 'wobwob',
                 },
                 'somethingelse',
                 ],
             'mynestedlistofcomponents': [[{
-                '__factory__': 'palladium.tests.test_util.MyDummyComponent',
+                '__factory__': dummy,
                 'arg1': 'feep',
+                'arg2': {
+                    '__factory__': dummy,
+                    'arg1': 6,
                 },
-                ]],
+            }]],
             'myconstant': 42,
             }
 
@@ -120,9 +124,10 @@ class TestInitializeConfigImpl:
         assert mylistofcomponents[0].arg1 == 'wobwob'
         assert mylistofcomponents[1] == 'somethingelse'
 
-        mynestedlistofcomponents = config['mynestedlistofcomponents']
-        assert isinstance(mynestedlistofcomponents[0][0], MyDummyComponent)
-        assert mynestedlistofcomponents[0][0].arg1 == 'feep'
+        mnl = config['mynestedlistofcomponents']
+        assert isinstance(mnl[0][0], MyDummyComponent)
+        assert mnl[0][0].arg1 == 'feep'
+        assert isinstance(mnl[0][0].arg2, MyDummyComponent)
 
     def test_initialize_config_logging(self, _initialize_config):
         with patch('palladium.util.dictConfig') as dictConfig:

--- a/palladium/tests/test_util.py
+++ b/palladium/tests/test_util.py
@@ -86,6 +86,11 @@ class TestInitializeConfigImpl:
                 },
                 'somethingelse',
                 ],
+            'mynestedlistofcomponents': [[{
+                '__factory__': 'palladium.tests.test_util.MyDummyComponent',
+                'arg1': 'feep',
+                },
+                ]],
             'myconstant': 42,
             }
 
@@ -114,6 +119,10 @@ class TestInitializeConfigImpl:
         assert isinstance(mylistofcomponents[0], MyDummyComponent)
         assert mylistofcomponents[0].arg1 == 'wobwob'
         assert mylistofcomponents[1] == 'somethingelse'
+
+        mynestedlistofcomponents = config['mynestedlistofcomponents']
+        assert isinstance(mynestedlistofcomponents[0][0], MyDummyComponent)
+        assert mynestedlistofcomponents[0][0].arg1 == 'feep'
 
     def test_initialize_config_logging(self, _initialize_config):
         with patch('palladium.util.dictConfig') as dictConfig:

--- a/palladium/util.py
+++ b/palladium/util.py
@@ -96,24 +96,24 @@ def initialize_config(**extra):
     return get_config(**extra)
 
 
-def _initialize_config_recursive(mapping):
+def _initialize_config_recursive(props):
     rv = []
-    if isinstance(mapping, dict):
-        for key, value in tuple(mapping.items()):
+    if isinstance(props, dict):
+        for key, value in tuple(props.items()):
             if isinstance(value, dict):
                 rv.extend(_initialize_config_recursive(value))
                 if '__factory__' in value:
-                    mapping[key] = create_component(value)
-                    rv.append(mapping[key])
+                    props[key] = create_component(value)
+                    rv.append(props[key])
             elif isinstance(value, (list, tuple)):
                 rv.extend(_initialize_config_recursive(value))
-    elif isinstance(mapping, (list, tuple)):
-        for i, item in enumerate(mapping):
+    elif isinstance(props, (list, tuple)):
+        for i, item in enumerate(props):
             if isinstance(item, dict):
                 rv.extend(_initialize_config_recursive(item))
                 if '__factory__' in item:
-                    mapping[i] = create_component(item)
-                    rv.append(mapping[i])
+                    props[i] = create_component(item)
+                    rv.append(props[i])
             elif isinstance(item, (list, tuple)):
                 rv.extend(_initialize_config_recursive(item))
     return rv

--- a/palladium/util.py
+++ b/palladium/util.py
@@ -98,19 +98,24 @@ def initialize_config(**extra):
 
 def _initialize_config_recursive(mapping):
     rv = []
-    for key, value in tuple(mapping.items()):
-        if isinstance(value, dict):
-            rv.extend(_initialize_config_recursive(value))
-            if '__factory__' in value:
-                mapping[key] = create_component(value)
-                rv.append(mapping[key])
-        elif isinstance(value, (list, tuple)):
-            for i, item in enumerate(value):
-                if isinstance(item, dict):
-                    rv.extend(_initialize_config_recursive(item))
-                    if '__factory__' in item:
-                        value[i] = create_component(item)
-                        rv.append(value[i])
+    if isinstance(mapping, dict):
+        for key, value in tuple(mapping.items()):
+            if isinstance(value, dict):
+                rv.extend(_initialize_config_recursive(value))
+                if '__factory__' in value:
+                    mapping[key] = create_component(value)
+                    rv.append(mapping[key])
+            elif isinstance(value, (list, tuple)):
+                rv.extend(_initialize_config_recursive(value))
+    elif isinstance(mapping, (list, tuple)):
+        for i, item in enumerate(mapping):
+            if isinstance(item, dict):
+                rv.extend(_initialize_config_recursive(item))
+                if '__factory__' in item:
+                    mapping[i] = create_component(item)
+                    rv.append(mapping[i])
+            elif isinstance(item, (list, tuple)):
+                rv.extend(_initialize_config_recursive(item))
     return rv
 
 


### PR DESCRIPTION
This is a work in progress!  Let me know what you think.

I've been looking at this since I wanted to define a pipeline purely through the configuration file.  This change should allow you to do something like this:

```python
    'model': {
        '__factory__': 'sklearn.pipeline.Pipeline',
        'steps': [['clf', {'__factory__': 'sklearn.linear_model.LinearRegression'}],
        ],
    },
```