### PR TITLE
Allow PALLADIUM_CONFIG to be a list of config files

### DIFF
--- a/palladium/tests/test_util.py
+++ b/palladium/tests/test_util.py
@@ -199,10 +199,9 @@ class TestGetConfig:
 
         assert config_new == {'a': 42, 'b': 7}
 
-        # Files earlier in the list override files later in the list,
-        # just like with Python's class inheritance:
+        # Files later in the list override files earlier in the list:
         assert fake_open.call_args_list == [
-            call('andanother'), call('somepath')]
+            call('somepath'), call('andanother')]
 
     def test_read_environ(self, get_config, config):
         config.initialized = False

--- a/palladium/util.py
+++ b/palladium/util.py
@@ -77,15 +77,16 @@ def get_config(**extra):
     if not _config.initialized:
         _config.update(extra)
         _config.initialized = True
-        fname = os.environ.get('PALLADIUM_CONFIG')
-        if fname is not None:
-            sys.path.insert(0, os.path.dirname(fname))
-
-            with open(fname) as f:
-                _config.update(
-                    eval(f.read(), {'environ': os.environ})
-                    )
-                _initialize_config(_config)
+        fnames = os.environ.get('PALLADIUM_CONFIG')
+        if fnames is not None:
+            fnames = [fname.strip() for fname in fnames.split(',')]
+            sys.path.insert(0, os.path.dirname(fnames[0]))
+            for fname in reversed(fnames):
+                with open(fname) as f:
+                    _config.update(
+                        eval(f.read(), {'environ': os.environ})
+                        )
+            _initialize_config(_config)
 
     return _config
 

--- a/palladium/util.py
+++ b/palladium/util.py
@@ -81,7 +81,7 @@ def get_config(**extra):
         if fnames is not None:
             fnames = [fname.strip() for fname in fnames.split(',')]
             sys.path.insert(0, os.path.dirname(fnames[0]))
-            for fname in reversed(fnames):
+            for fname in fnames:
                 with open(fname) as f:
                     _config.update(
                         eval(f.read(), {'environ': os.environ})


### PR DESCRIPTION
Implements 'configuration inheritance'.  This allows us to write:

`PALLADIUM_CONFIG=etc/myconfig.py,etc/mybaseconfig.py`

Entries in the configuration files earlier in the list will override those later in the list: If the contents of `etc/mybaseconfig.py` is `"{'a': 42, 'b': 6}"` and the contents of `etc/myconfig.py` is `{'b': 7}`, then the resulting configuration will be `{'a': 42, 'b': 7}`.

Let me know what you think.

**EDIT**: Had the example the wrong way around.