### PR TITLE
Add poolclass parameter to Database model persister

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,13 @@ before_install:
   - sudo add-apt-repository -y ppa:marutter/rdev
   - sudo apt-get update -qq
   - sudo apt-get install -qq libatlas-dev libatlas-base-dev liblapack-dev gfortran r-base
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
-  - export PATH=/home/travis/miniconda2/bin:$PATH
+  - export PATH=/home/travis/miniconda3/bin:$PATH
   - conda update --yes conda
   - travis_retry conda install --yes python=$TRAVIS_PYTHON_VERSION --file requirements.txt
-  - sudo rm /home/travis/miniconda2/lib/libgfortran* # get rid of conflicting lib (rpy2/R)
+  - sudo rm /home/travis/miniconda3/lib/libgfortran* # get rid of conflicting lib (rpy2/R)
   - pip install pytest pytest-cov
   - pip install coveralls
 install:

--- a/palladium/tests/test_persistence.py
+++ b/palladium/tests/test_persistence.py
@@ -6,7 +6,6 @@ from threading import Thread
 from unittest.mock import Mock
 from unittest.mock import MagicMock
 from unittest.mock import patch
-from time import sleep
 
 import pytest
 

--- a/palladium/tests/test_persistence.py
+++ b/palladium/tests/test_persistence.py
@@ -18,37 +18,6 @@ class Dummy:
         return vars(self) == vars(other)
 
 
-def create_dbmodel(database):
-    from palladium.util import session_scope
-
-    model = Dummy(
-        name='mymodel',
-        __metadata__={'some': 'metadata', 'version': 1},
-    )
-
-    model_blob = gzip.compress(pickle.dumps(model), compresslevel=0)
-    chunk_size = 4
-    chunks = [model_blob[i:i + chunk_size]
-              for i in range(0, len(model_blob), chunk_size)]
-
-    dbmodel = database.DBModel(
-        version=1,
-        chunks=[
-            database.DBModelChunk(
-                model_version=1,
-                blob=chunk,
-            )
-            for chunk in chunks
-        ],
-        metadata_=json.dumps(model.__metadata__),
-    )
-
-    with session_scope(database.session) as session:
-        session.add(dbmodel)
-
-    return model
-
-
 class TestUpgradeSteps:
     @pytest.fixture
     def steps(self):
@@ -420,22 +389,34 @@ class TestDatabase:
 
     @pytest.fixture
     def dbmodel(self, database):
-        return create_dbmodel(database)
+        from palladium.util import session_scope
 
-    @pytest.fixture
-    def DatabaseCLOB(self):
-        from palladium.persistence import DatabaseCLOB
-        return DatabaseCLOB
-        
-    @pytest.fixture
-    def database_clob(self, request, DatabaseCLOB):
-        path = '/tmp/palladium.testing-{}.sqlite'.format(os.getpid())
-        request.addfinalizer(lambda: os.remove(path))
-        return DatabaseCLOB('sqlite:///{}'.format(path), chunk_size=4)
+        model = Dummy(
+            name='mymodel',
+            __metadata__={'some': 'metadata', 'version': 1},
+            )
 
-    @pytest.fixture
-    def dbmodel_clob(self, database_clob):
-        return create_dbmodel(database_clob)
+        model_blob = gzip.compress(pickle.dumps(model), compresslevel=0)
+        chunk_size = 4
+        chunks = [model_blob[i:i + chunk_size]
+                  for i in range(0, len(model_blob), chunk_size)]
+
+        dbmodel = database.DBModel(
+            version=1,
+            chunks=[
+                database.DBModelChunk(
+                    model_version=1,
+                    blob=chunk,
+                    )
+                for chunk in chunks
+                ],
+            metadata_=json.dumps(model.__metadata__),
+            )
+
+        with session_scope(database.session) as session:
+            session.add(dbmodel)
+
+        return model
 
     def test_initialize_properties(self, database):
         from palladium import __version__
@@ -445,11 +426,6 @@ class TestDatabase:
         database.write(Dummy(name='mymodel'))
         database.activate(1)
         assert database.read() == dbmodel
-
-    def test_read_clob(self, database_clob, dbmodel_clob):
-        database_clob.write(Dummy(name='mymodel'))
-        database_clob.activate(1)
-        assert database_clob.read() == dbmodel_clob
 
     def test_read_with_version(self, database, dbmodel):
         database.write(Dummy(name='mymodel'))
@@ -582,14 +558,6 @@ class TestDatabase:
         assert database.list_properties() == {
             'db-version': '1.0', 'active-model': '2'}
 
-    def test_table_postfix_default(self, Database, request):
-        path = '/tmp/palladium.testing-{}.sqlite'.format(os.getpid())
-        request.addfinalizer(lambda: os.remove(path))
-        db = Database('sqlite:///{}'.format(path))
-        assert db.Property.__tablename__ == 'properties'
-        assert db.DBModel.__tablename__ == 'models'
-        assert db.DBModelChunk.__tablename__ == 'model_chunks'
-
     def test_table_postfix(self, Database, request):
         path = '/tmp/palladium.testing-{}.sqlite'.format(os.getpid())
         request.addfinalizer(lambda: os.remove(path))
@@ -611,6 +579,13 @@ class TestDatabase:
         request.addfinalizer(lambda: os.remove(path))
         db = Database('sqlite:///{}'.format(path), poolclass=QueuePool)
         assert isinstance(db.engine.pool, QueuePool)
+
+
+class TestDatabaseCLOB(TestDatabase):
+    @pytest.fixture
+    def Database(self):
+        from palladium.persistence import DatabaseCLOB
+        return DatabaseCLOB
 
 
 class TestCachedUpdatePersister:

--- a/palladium/tests/test_persistence.py
+++ b/palladium/tests/test_persistence.py
@@ -558,6 +558,14 @@ class TestDatabase:
         assert database.list_properties() == {
             'db-version': '1.0', 'active-model': '2'}
 
+    def test_table_postfix_default(self, Database, request):
+        path = '/tmp/palladium.testing-{}.sqlite'.format(os.getpid())
+        request.addfinalizer(lambda: os.remove(path))
+        db = Database('sqlite:///{}'.format(path))
+        assert db.Property.__tablename__ == 'properties'
+        assert db.DBModel.__tablename__ == 'models'
+        assert db.DBModelChunk.__tablename__ == 'model_chunks'
+
     def test_table_postfix(self, Database, request):
         path = '/tmp/palladium.testing-{}.sqlite'.format(os.getpid())
         request.addfinalizer(lambda: os.remove(path))


### PR DESCRIPTION
The default of sqlalchemy's create_engine uses connection pooling. This can lead to problems if many concurrent Palladium instances are started at once as DB connections are left open. With this change it is possible to set the poolclass in the Database's init. The NullPool is used as default, i.e., pooling is deactivated.