### PR TITLE
Allow for use of multiple CachedUpdatePersisters

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,15 @@
 v1.2 - unreleased
 =================
 
+- Allow for use of multiple CachedUpdatePersisters
+
+  Instances of CachedUpdatePersister now use their own name inside the
+  configuration file to index into `process_store`.  That is, a
+  CachedUpdatePersister that's configured as `my_model_persister`
+  inside the configuration file will have an entry in `process_store`
+  with the key `my_model_persister`.  This is a breaking change, since
+  the previously used key `model` is no longer available.
+
 - Add a model persister for REST backends, e.g. for use with Artifactory.
 
 

--- a/palladium/config.py
+++ b/palladium/config.py
@@ -44,6 +44,10 @@ class ComponentHandler:
         factory_dotted_name = specification.pop(self.key)
         factory = resolve_dotted_name(factory_dotted_name)
         component = factory(**specification)
+        try:
+            component.__pld_config_key__ = self.key
+        except AttributeError:
+            pass
         self.components.append(component)
         return component
 

--- a/palladium/persistence.py
+++ b/palladium/persistence.py
@@ -568,7 +568,7 @@ class CachedUpdatePersister(ModelPersister):
     """
 
     cache = process_store
-    key = 'model'
+    __pld_config_key__ = 'cachedupdatepersister_default'
 
     def __init__(self,
                  impl,
@@ -605,7 +605,7 @@ class CachedUpdatePersister(ModelPersister):
 
     def read(self, *args, **kwargs):
         if self.use_cache:
-            return self.cache[self.key]
+            return self.cache[self.__pld_config_key__]
         else:
             return self.impl.read(*args, **kwargs)
 
@@ -613,7 +613,7 @@ class CachedUpdatePersister(ModelPersister):
     def update_cache(self, *args, **kwargs):
         model = self.impl.read(*args, **kwargs)
         if model is not None:
-            self.cache[self.key] = model
+            self.cache[self.__pld_config_key__] = model
             return model
 
     @PluggableDecorator('write_model_decorators')

--- a/palladium/tests/test_persistence.py
+++ b/palladium/tests/test_persistence.py
@@ -760,7 +760,8 @@ class TestCachedUpdatePersister:
         assert persister.read() is persister.impl.read.return_value
 
     def test_read_custom_value(self, process_store, persister):
-        process_store['model'] = 'mymodel'
+        persister.__pld_config_key__ = 'myname'
+        process_store['myname'] = 'mymodel'
         assert persister.read() == 'mymodel'
 
     def test_write(self, persister):
@@ -781,9 +782,10 @@ class TestCachedUpdatePersister:
 
         impl = MagicMock()
         persister = CachedUpdatePersister(impl, update_cache_rrule=rrule_info)
+        persister.__pld_config_key__ = 'mypersister'
         persister.initialize_component(config)
         assert persister.read() is impl.read.return_value
-        assert process_store['model'] is impl.read.return_value
+        assert process_store['mypersister'] is impl.read.return_value
         assert impl.read.call_count == 1
 
     def test_dont_cache(self, process_store, CachedUpdatePersister, config):


### PR DESCRIPTION
Instances of CachedUpdatePersister now use their own name inside the
configuration file to index into `process_store`.  That is, a
CachedUpdatePersister that's configured as `my_model_persister` inside
the configuration file will have an entry in `process_store` with the
key `my_model_persister`.  This is a breaking change, since the
previously used key `model` is no longer available.