### PR TITLE
No longer disallow recursive call to get_config (reverts e390cbf)

### DIFF
--- a/palladium/config.py
+++ b/palladium/config.py
@@ -13,30 +13,6 @@ PALLADIUM_CONFIG_ERROR = """
 """
 
 
-PALLADIUM_RECURSIVE_GET_CONFIG_ERROR = """
-  You're trying to call `get_config` from code that's already called by
-  `get_config`.  Thus, there's unfortunately no way we can guarantee
-  that the part of the config that you're interested in is already
-  properly resolved and initialized.
-
-  Please consider either implementing the `initialize_component(config)`
-  method in your class, which gets passed the initialized configuration
-  as an argument, and use that to do final initialization of your model
-  using the configuration.  Or pass in the configuration that you want
-  to access as part of your components config.  So if possible, instead
-  of:
-
-    {'mycomponent': {...}, 'mydependency': {...}}
-
-  write this:
-
-    {'mycomponent': {'mydependency': {...}, ...}}
-
-  Use of @args_from_config for functions that get called by
-  configuration code is prohibited for the same reason.
-"""
-
-
 class Config(dict):
     """A dictionary that represents the app's configuration.
 
@@ -223,20 +199,12 @@ def process_config(
     return config_final
 
 
-_get_config_lock = threading.Lock()
-_get_config_lock_owner = None
+_get_config_lock = threading.RLock()
 
 
 def get_config(**extra):
-    global _get_config_lock_owner
-    if _get_config_lock_owner == threading.get_ident():
-        raise ValueError(PALLADIUM_RECURSIVE_GET_CONFIG_ERROR)
     with _get_config_lock:
-        _get_config_lock_owner = threading.get_ident()
-        try:
-            config = _get_config(**extra)
-        finally:
-            _get_config_lock_owner = None
+        config = _get_config(**extra)
     return config
 
 

--- a/palladium/tests/test_config.py
+++ b/palladium/tests/test_config.py
@@ -134,17 +134,6 @@ class TestGetConfig:
 
         assert reduce(operator.eq, cfg.values())
 
-    def test_recursive_call_of_get_config(
-        self,
-        get_config,
-        config3_fname,
-        monkeypatch,
-    ):
-        monkeypatch.setitem(os.environ, 'PALLADIUM_CONFIG', config3_fname)
-        with pytest.raises(ValueError) as exc:
-            get_config()
-        assert "You're trying to call `get_config` from code" in str(exc.value)
-
 
 class TestProcessConfig:
     @pytest.fixture


### PR DESCRIPTION
It turns out that we make use of recursive `get_config` calls in our
own code: `CachedUpdatePersister` initializes with
`self.update_cache()`, which is decorated with
`PluggableDecorator('update_model_decorators')`, which calls
`get_config` to get a list of strings pointing to decorator functions.

In any event, it may be a good idea to call `self.update_cache()` from
a thread so to not block initialization.  However,
`PluggableDecorator` likely has other legitimate uses, so this isn't a
fix for the problem at hand.

The caveat still applies that if one calls `get_config` from component
code, one must be aware that the part of config we want to refer to
may not be initialized yet.  Best way to work around this is to either
not rely on `__factory__` and friends at all (PluggableDecorator does
that), or to make that part of the configuration a sub-entry to the
component's own configuration, if possible.