### PR TITLE
Upgrade rpy2 to 2.9.0 in attempt to fix error on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,12 @@ before_install:
   - echo "deb https://cran.rstudio.com/bin/linux/ubuntu $codename/" | sudo tee -a /etc/apt/sources.list > /dev/null
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
   - sudo add-apt-repository -y ppa:marutter/rdev
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get update -qq
   - sudo apt-get install -qq libatlas-dev libatlas-base-dev liblapack-dev gfortran r-base
+  - sudo apt-get install -qq gcc-5 g++-5
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5
+  - gcc --version
   - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b


### PR DESCRIPTION
Error:

    gcc -pthread -shared -L/home/travis/miniconda3/lib -B /home/travis/miniconda3/compiler_compat -Wl,-rpath=/home/travis/miniconda3/lib,--no-as-needed build/temp.linux-x86_64-3.5/./rpy/rinterface/_rinterface.o -L/usr/lib/R/lib -L/home/travis/miniconda3/lib -Lbuild/temp.linux-x86_64-3.5 -R/usr/lib/R/lib -lR -lpcre -llzma -lbz2 -lz -lrt -ldl -lm -lpython3.5m -lr_utils -o build/lib.linux-x86_64-3.5/rpy2/rinterface/_rinterface.cpython-35m-x86_64-linux-gnu.so -Wl,--export-dynamic -fopenmp -Wl,-Bsymbolic-functions -Wl,-z,relro
    gcc: error: unrecognized command line option ‘-R’
    error: command 'gcc' failed with exit status 1