### PR TITLE
fix encodeings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ docs_require = [
 
 here = os.path.abspath(os.path.dirname(__file__))
 try:
-    README = open(os.path.join(here, 'README.rst')).read()
-    CHANGES = open(os.path.join(here, 'CHANGES.txt')).read()
+    README = open(os.path.join(here, 'README.rst'), encoding='utf-8').read()
+    CHANGES = open(os.path.join(here, 'CHANGES.txt'), encoding='utf-8').read()
 except IOError:
     README = CHANGES = ''
 


### PR DESCRIPTION
Working in an ubuntu16.04 based docker container:

```
root@ca3baaf4f4fd:/lotik-ml# uname -a
Linux ca3baaf4f4fd 4.4.0-97-generic #120-Ubuntu SMP Tue Sep 19 17:28:18 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
root@ca3baaf4f4fd:/lotik-ml# cat /proc/version_signature
Ubuntu 4.4.0-97.120-generic 4.4.87
```

I received this error during pip installation of develop branch:
```
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/lotik-ml/src/palladium/setup.py", line 34, in <module>
        README = open(os.path.join(here, 'README.rst')).read()
      File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 3115: ordinal not in range(128)
```