### PR TITLE
/fit entry point that allows fitting through the web

### DIFF
--- a/docs/user/web-service.rst
+++ b/docs/user/web-service.rst
@@ -193,7 +193,7 @@ method:
 
 - In multi-server or multi-process environments, you must take care of
   updating existing model caches (e.g. when running
-  :class:`palladium.persistence.CachedUpdatePersister`) by hand.  This
+  :class:`~palladium.persistence.CachedUpdatePersister`) by hand.  This
   can be done by calling the */update-model-cache* endpoint for each
   server process.
 
@@ -242,4 +242,28 @@ the same way that */refit* does, that is, by returning an id and
 storing information about the job inside of ``process_metadata``.
 */update-model-cache* will update the cache of any caching model
 persisters, such as
-:class:`palladium.persistence.CachedUpdatePersister`.
+:class:`~palladium.persistence.CachedUpdatePersister`.
+
+The */refit* and */update-model-cache* endpoints aren't registered by
+default with the Flask app.  To register the two endpoints, you can
+either call the Flask app's ``add_url_rules`` directly or use the
+convenience function :func:`palladium.server.add_url_rule` instead
+inside of your configuration file.  An example of registering the two
+endpoints is this:
+
+.. code-block:: python
+
+    'flask_add_url_rules': [
+        {
+            '__factory__': 'palladium.server.add_url_rule',
+            'rule': '/refit',
+            'view_func': 'palladium.server.refit',
+            'methods': ['POST'],
+        },
+        {
+            '__factory__': 'palladium.server.add_url_rule',
+            'rule': '/update-model-cache',
+            'view_func': 'palladium.server.update_model_cache',
+            'methods': ['POST'],
+        },
+    ],

--- a/docs/user/web-service.rst
+++ b/docs/user/web-service.rst
@@ -170,8 +170,8 @@ configuration the following entry:
         'process_store_required': ['data'],
         },
 
-Refit and Update Model Cache
-----------------------------
+Fit and Update Model Cache
+--------------------------
 
 Palladium allows for periodic updates of the model by use of the
 :class:`palladium.persistence.CachedUpdatePersister`.  For this to
@@ -181,7 +181,7 @@ process runs ``pld-fit`` and saves a new model into the same model
 database.  When ``pld-fit`` is done, the web services will load the
 new model as part of the next periodic update.
 
-The second option is to call the */refit* web service endpoint, which
+The second option is to call the */fit* web service endpoint, which
 will essentially run the equivalent of ``pld-fit``, but in the web
 service's process.  This has a few drawbacks compared to the first
 method:
@@ -197,10 +197,10 @@ method:
   can be done by calling the */update-model-cache* endpoint for each
   server process.
 
-An example request to trigger a refit looks like this (assuming that
+An example request to trigger a fit looks like this (assuming that
 you're running a server locally on port 5000):
 
-  http://localhost:5000/refit?evaluate=false&persist_if_better_than=0.9
+  http://localhost:5000/fit?evaluate=false&persist_if_better_than=0.9
 
 The request will return immediately, after spawning a thread to do the
 actual fitting work.  The JSON response has the job's ID, which we'll
@@ -238,13 +238,13 @@ function's return value.
 
 When using a cached persister, you may also want to run the
 */update-model-cache* endpoint, which runs another job asynchronously,
-the same way that */refit* does, that is, by returning an id and
+the same way that */fit* does, that is, by returning an id and
 storing information about the job inside of ``process_metadata``.
 */update-model-cache* will update the cache of any caching model
 persisters, such as
 :class:`~palladium.persistence.CachedUpdatePersister`.
 
-The */refit* and */update-model-cache* endpoints aren't registered by
+The */fit* and */update-model-cache* endpoints aren't registered by
 default with the Flask app.  To register the two endpoints, you can
 either call the Flask app's ``add_url_rules`` directly or use the
 convenience function :func:`palladium.server.add_url_rule` instead
@@ -256,8 +256,8 @@ endpoints is this:
     'flask_add_url_rules': [
         {
             '__factory__': 'palladium.server.add_url_rule',
-            'rule': '/refit',
-            'view_func': 'palladium.server.refit',
+            'rule': '/fit',
+            'view_func': 'palladium.server.fit',
             'methods': ['POST'],
         },
         {

--- a/docs/user/web-service.rst
+++ b/docs/user/web-service.rst
@@ -137,16 +137,17 @@ entry. Here is an example for the Iris service:
       "palladium_version": "0.6",
       "service_metadata": {
           "service_name": "iris",
-	  "service_version": "0.1"
+          "service_version": "0.1"
       },
       "memory_usage": 78,
       "model": {
           "updated": "2015-02-18T10:13:50.024478",
-	  "metadata": {
-	      "version": 2,
-	      "train_timestamp": "2015-02-18T09:59:34.480063"
-	  }
-      }
+          "metadata": {
+                "version": 2,
+                "train_timestamp": "2015-02-18T09:59:34.480063"
+          }
+      },
+      "process_metadata": {}
   }
 
 */alive* can optionally check for the presence of data loaded into the
@@ -168,3 +169,77 @@ configuration the following entry:
     'alive': {
         'process_store_required': ['data'],
         },
+
+Refit and Update Model Cache
+----------------------------
+
+Palladium allows for periodic updates of the model by use of the
+:class:`palladium.persistence.CachedUpdatePersister`.  For this to
+work, the web service's model persister checks its model database
+source periodically for new versions of the model.  Meanwhile, another
+process runs ``pld-fit`` and saves a new model into the same model
+database.  When ``pld-fit`` is done, the web services will load the
+new model as part of the next periodic update.
+
+The second option is to call the */refit* web service endpoint, which
+will essentially run the equivalent of ``pld-fit``, but in the web
+service's process.  This has a few drawbacks compared to the first
+method:
+
+- The fitting will run inside the same process as the web service.
+  While the model is fitting, your web service will likely use
+  considerably more memory and processing while the fitting is
+  underway.
+
+- In multi-server or multi-process environments, you must take care of
+  updating existing model caches (e.g. when running
+  :class:`palladium.persistence.CachedUpdatePersister`) by hand.  This
+  can be done by calling the */update-model-cache* endpoint for each
+  server process.
+
+An example request to trigger a refit looks like this (assuming that
+you're running a server locally on port 5000):
+
+  http://localhost:5000/refit?evaluate=false&persist_if_better_than=0.9
+
+The request will return immediately, after spawning a thread to do the
+actual fitting work.  The JSON response has the job's ID, which we'll
+later require next to check the status of our job:
+
+.. code-block:: json
+
+  {"job_id": "1adf9b2d-0160-45f3-a81b-4d8e4edf2713"}
+
+The */alive* endpoint returns information about all jobs inside of the
+``service_metadata.jobs`` entry.  After submitting above job, we'll
+find that calling */alive* returns something like this:
+
+.. code-block:: json
+
+  {
+      "palladium_version": "0.6",
+      // ...
+      "process_metadata": {
+          "jobs": {
+              "1adf9b2d-0160-45f3-a81b-4d8e4edf2713": {
+                  "func": "<fit function>",
+                  "info": "<MyModel>",
+                  "started": "2018-04-09 09:44:52.660732",
+                  "status": "finished",
+                  "thread": 139693771835136
+              }
+          }
+      }
+  }
+
+The ``finished`` status indicates that the job was successfully
+completed.  ``info`` contains a string representation of the
+function's return value.
+
+When using a cached persister, you may also want to run the
+*/update-model-cache* endpoint, which runs another job asynchronously,
+the same way that */refit* does, that is, by returning an id and
+storing information about the job inside of ``process_metadata``.
+*/update-model-cache* will update the cache of any caching model
+persisters, such as
+:class:`palladium.persistence.CachedUpdatePersister`.

--- a/palladium/server.py
+++ b/palladium/server.py
@@ -373,7 +373,7 @@ Options:
 
 
 @app.route('/refit', methods=['POST'])
-@PluggableDecorator('retrain_decorators')
+@PluggableDecorator('refit_decorators')
 @args_from_config
 def refit():
     param_converters = {
@@ -389,3 +389,15 @@ def refit():
         }
     thread, job_id = run_job(fit, **params)
     return make_ujson_response({'job_id': job_id}, status_code=200)
+
+
+@app.route('/update-model-cache', methods=['POST'])
+@PluggableDecorator('update_model_cache_decorators')
+@args_from_config
+def update_model_cache(model_persister):
+    method = getattr(model_persister, 'update_cache', None)
+    if method is not None:
+        thread, job_id = run_job(model_persister.update_cache)
+        return make_ujson_response({'job_id': job_id}, status_code=200)
+    else:
+        return make_ujson_response({}, status_code=503)

--- a/palladium/server.py
+++ b/palladium/server.py
@@ -12,7 +12,7 @@ import ujson
 from werkzeug.exceptions import BadRequest
 
 from . import __version__
-from .fit import fit
+from .fit import fit as fit_base
 from .interfaces import PredictError
 from .util import args_from_config
 from .util import get_config
@@ -373,9 +373,9 @@ Options:
     stream.listen(sys.stdin, sys.stdout, sys.stderr)
 
 
-@PluggableDecorator('refit_decorators')
+@PluggableDecorator('fit_decorators')
 @args_from_config
-def refit():
+def fit():
     param_converters = {
         'persist': lambda x: x.lower() in ('1', 't', 'true'),
         'activate': lambda x: x.lower() in ('1', 't', 'true'),
@@ -387,7 +387,7 @@ def refit():
         for name, typ in param_converters.items()
         if name in request.form
         }
-    thread, job_id = run_job(fit, **params)
+    thread, job_id = run_job(fit_base, **params)
     return make_ujson_response({'job_id': job_id}, status_code=200)
 
 

--- a/palladium/server.py
+++ b/palladium/server.py
@@ -23,6 +23,7 @@ from .util import memory_usage_psutil
 from .util import PluggableDecorator
 from .util import process_store
 from .util import run_job
+from .util import resolve_dotted_name
 
 app = Flask(__name__)
 
@@ -372,7 +373,6 @@ Options:
     stream.listen(sys.stdin, sys.stdout, sys.stderr)
 
 
-@app.route('/refit', methods=['POST'])
 @PluggableDecorator('refit_decorators')
 @args_from_config
 def refit():
@@ -401,3 +401,9 @@ def update_model_cache(model_persister):
         return make_ujson_response({'job_id': job_id}, status_code=200)
     else:
         return make_ujson_response({}, status_code=503)
+
+
+def add_url_rule(rule, endpoint=None, view_func=None, app=app, **options):
+    if isinstance(view_func, str):
+        view_func = resolve_dotted_name(view_func)
+    app.add_url_rule(rule, endpoint=endpoint, view_func=view_func, **options)

--- a/palladium/tests/conftest.py
+++ b/palladium/tests/conftest.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import pytest
 
 
@@ -9,9 +10,7 @@ def flask_client(flask_app):
 @pytest.fixture
 def process_store(request):
     from palladium.util import process_store
-
-    orig = process_store.copy()
+    orig = deepcopy(process_store)
+    yield process_store
     process_store.clear()
-    request.addfinalizer(
-        lambda: (process_store.clear(), process_store.update(orig)))
-    return process_store
+    process_store.update(orig)

--- a/palladium/tests/test_persistence.py
+++ b/palladium/tests/test_persistence.py
@@ -810,11 +810,12 @@ class TestCachedUpdatePersister:
             'dtstart': '2014-10-30T13:21:18',
             }
 
+        len_before = len(process_store)
         impl = MagicMock()
         persister = CachedUpdatePersister(impl, update_cache_rrule=rrule_info)
         persister.initialize_component(config)
         assert persister.read() is impl.read.return_value
-        assert len(process_store) == 0
+        assert len(process_store) == len_before
         assert persister.thread is None
 
     def test_proxy_list_models(self, CachedUpdatePersister):

--- a/palladium/tests/test_server.py
+++ b/palladium/tests/test_server.py
@@ -563,11 +563,11 @@ class TestPredictStream:
         assert model.predict.call_args[1]['magic'] is False
 
 
-class TestRefitFunctional:
+class TestFitFunctional:
     @pytest.fixture
-    def refit(self):
-        from palladium.server import refit
-        return refit
+    def fit(self):
+        from palladium.server import fit
+        return fit
 
     @pytest.fixture
     def jobs(self, process_store):
@@ -575,7 +575,7 @@ class TestRefitFunctional:
         yield jobs
         jobs.clear()
 
-    def test_it(self, refit, config, jobs, flask_app):
+    def test_it(self, fit, config, jobs, flask_app):
         dsl, model, model_persister = Mock(), Mock(), Mock()
         X, y = Mock(), Mock()
         dsl.return_value = X, y
@@ -583,7 +583,7 @@ class TestRefitFunctional:
         config['model'] = model
         config['model_persister'] = model_persister
         with flask_app.test_request_context(method='POST'):
-            resp = refit()
+            resp = fit()
         sleep(0.005)
         resp_json = json.loads(resp.get_data(as_text=True))
         job = jobs[resp_json['job_id']]
@@ -600,13 +600,13 @@ class TestRefitFunctional:
             {'persist_if_better_than': 0.234},
         ),
     ])
-    def test_pass_args(self, refit, flask_app, args, args_expected):
-        with patch('palladium.server.fit') as fit:
-            fit.__name__ = 'mock'
+    def test_pass_args(self, fit, flask_app, args, args_expected):
+        with patch('palladium.server.fit_base') as fit_base:
+            fit_base.__name__ = 'mock'
             with flask_app.test_request_context(method='POST', data=args):
-                refit()
+                fit()
             sleep(0.005)
-        assert fit.call_args == call(**args_expected)
+        assert fit_base.call_args == call(**args_expected)
 
 
 class TestUpdateModelCacheFunctional:

--- a/palladium/tests/test_util.py
+++ b/palladium/tests/test_util.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import threading
 from time import sleep
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -337,3 +338,75 @@ class TestPartial:
         Partial('palladium.tests.test_util:TestPartial.myfunc', two=2)(one='one')
         assert self.calls == [('one', 2, 'three')]
         self.__class__.calls = []
+
+
+class TestRunJob:
+    @pytest.fixture
+    def run_job(self):
+        from palladium.util import run_job
+        return run_job
+
+    @pytest.fixture
+    def jobs(self, process_store):
+        jobs = process_store['process_metadata']['jobs'] = {}
+        yield jobs
+        jobs.clear()
+
+    def test_simple(self, run_job, jobs):
+        def myfunc(add):
+            nonlocal result
+            result += add
+            return add
+
+        result = 0
+        results = []
+        for i in range(3):
+            results.append(run_job(myfunc, add=i))
+        sleep(0.01)
+        assert result == 3
+        assert len(jobs) == len(results) == 3
+        assert set(jobs.keys()) == set(r[1] for r in results)
+        assert all(j['status'] == 'finished' for j in jobs.values())
+        assert set(j['info'] for j in jobs.values()) == set(['0', '1', '2'])
+
+    def test_exception(self, run_job, jobs):
+        def myfunc(divisor):
+            nonlocal result
+            result /= divisor
+
+        result = 1
+        num_threads_before = len(threading.enumerate())
+        for i in range(3):
+            run_job(myfunc, divisor=i)
+        sleep(0.01)
+        num_threads_after = len(threading.enumerate())
+
+        assert num_threads_before == num_threads_after
+        assert result == 0.5
+        job1, job2, job3 = sorted(jobs.values(), key=lambda x: x['started'])
+        assert job1['status'] == 'error'
+        assert 'division by zero' in job1['info']
+        assert job2['status'] == 'finished'
+        assert job3['status'] == 'finished'
+
+    def test_lifecycle(self, run_job, jobs):
+        def myfunc(tts):
+            sleep(tts)
+
+        num_threads_before = len(threading.enumerate())
+        for i in range(3):
+            run_job(myfunc, tts=i/100)
+
+        job1, job2, job3 = sorted(jobs.values(), key=lambda x: x['started'])
+        assert job1['status'] == 'finished'
+        assert job2['status'] == job3['status'] == 'running'
+        assert len(threading.enumerate()) - num_threads_before == 2
+
+        sleep(0.015)
+        assert job2['status'] == 'finished'
+        assert job3['status'] == 'running'
+        assert len(threading.enumerate()) - num_threads_before == 1
+
+        sleep(0.015)
+        assert job3['status'] == 'finished'
+        assert len(threading.enumerate()) - num_threads_before == 0

--- a/palladium/tests/test_util.py
+++ b/palladium/tests/test_util.py
@@ -94,11 +94,11 @@ class TestProcessStore:
     def test_mtime_setitem(self, store):
         dt0 = datetime.now()
         store['somekey'] = '1'
-        sleep(0.001)  # make sure that we're not too fast
+        sleep(0.005)  # make sure that we're not too fast
         dt1 = datetime.now()
         assert dt0 < store.mtime['somekey'] < dt1
         store['somekey'] = '2'
-        sleep(0.001)  # make sure that we're not too fast
+        sleep(0.005)  # make sure that we're not too fast
         dt2 = datetime.now()
         assert dt1 < store.mtime['somekey'] < dt2
 
@@ -362,7 +362,7 @@ class TestRunJob:
         results = []
         for i in range(3):
             results.append(run_job(myfunc, add=i))
-        sleep(0.01)
+        sleep(0.005)
         assert result == 3
         assert len(jobs) == len(results) == 3
         assert set(jobs.keys()) == set(r[1] for r in results)
@@ -378,7 +378,7 @@ class TestRunJob:
         num_threads_before = len(threading.enumerate())
         for i in range(3):
             run_job(myfunc, divisor=i)
-        sleep(0.01)
+        sleep(0.005)
         num_threads_after = len(threading.enumerate())
 
         assert num_threads_before == num_threads_after

--- a/palladium/util.py
+++ b/palladium/util.py
@@ -299,7 +299,7 @@ def Partial(func, **kwargs):
 def _run_job(func, job_id, params):
     jobs = process_store['process_metadata'].setdefault('jobs', {})
     job = jobs[job_id] = {
-        'func': func.__name__,
+        'func': repr(func),
         'started': str(datetime.utcnow()),
         'status': 'running',
         'thread': threading.get_ident(),

--- a/palladium/util.py
+++ b/palladium/util.py
@@ -13,9 +13,11 @@ from inspect import signature
 from inspect import getcallargs
 import os
 import sys
-from threading import Thread
+import threading
 from time import sleep
 from time import time
+import traceback
+import uuid
 
 import dateutil.parser
 import dateutil.rrule
@@ -123,10 +125,10 @@ class ProcessStore(UserDict):
         del self.mtime[key]
 
 
-process_store = ProcessStore()
+process_store = ProcessStore(process_metadata={})
 
 
-class RruleThread(Thread):
+class RruleThread(threading.Thread):
     """Calls a given function in intervals defined by given recurrence
     rules (from `datetuil.rrule`).
     """
@@ -292,3 +294,31 @@ def Partial(func, **kwargs):
     partial_func = partial(func, **kwargs)
     update_wrapper(partial_func, func)
     return partial_func
+
+
+def _run_job(func, job_id, params):
+    jobs = process_store['process_metadata'].setdefault('jobs', {})
+    job = jobs[job_id] = {
+        'func': func.__name__,
+        'started': str(datetime.utcnow()),
+        'status': 'running',
+        'thread': threading.get_ident(),
+        }
+    try:
+        retval = func(**params)
+    except:
+        job['status'] = 'error'
+        job['info'] = traceback.format_exc()
+    else:
+        job['status'] = 'finished'
+        job['info'] = str(retval)
+
+
+def run_job(func, **params):
+    job_id = str(uuid.uuid4())
+    thread = threading.Thread(
+        target=_run_job,
+        kwargs={'func': func, 'job_id': job_id, 'params': params},
+        )
+    thread.start()
+    return thread, job_id


### PR DESCRIPTION
TODO:

- [x] Don't activate by default
- [x] Possibly allow optional reload/read of model persister after fit is done
- [x] Rename to /fit
- [x] Check support for starting a web service with no model, then running fit. (see #74)