### PR TITLE
Decorate all ModelPersister read() and write() methods automatically

### DIFF
--- a/palladium/interfaces.py
+++ b/palladium/interfaces.py
@@ -121,7 +121,14 @@ class PredictError(Exception):
         return "{} ({})".format(self.error_message, self.error_code)
 
 
-class ModelPersister(metaclass=ABCMeta):
+class ModelPersisterMeta(ABCMeta):
+    def __init__(cls, name, bases, attrs, **kwargs):
+        super().__init__(name, bases, attrs, **kwargs)
+        cls.read = PluggableDecorator('read_model_decorators')(cls.read)
+        cls.write = PluggableDecorator('write_model_decorators')(cls.write)
+
+
+class ModelPersister(metaclass=ModelPersisterMeta):
     @abstractmethod
     def read(self, version=None):
         """Returns a :class:`Model` instance.

--- a/palladium/persistence.py
+++ b/palladium/persistence.py
@@ -635,7 +635,6 @@ class CachedUpdatePersister(ModelPersister):
 
             return model
 
-    @PluggableDecorator('write_model_decorators')
     def write(self, model):
         return self.impl.write(model)
 


### PR DESCRIPTION
This removes the need to add the decorator in every class
individually, which is something that's easy to forget.

A side effect of this change is that for persisters that wrap other
persisters (such as the CachedUpdatePersister), the write decorator
will be called twice, since now both CachedUpdatePersister and the
underlying wrapped persister will fire and call the decorators.  I'm
considering this negligible; the effect is only felt with slow and non
idempotent code.