### PR TITLE
Avoid a 'hard error' when no model present at start-up

### DIFF
--- a/palladium/persistence.py
+++ b/palladium/persistence.py
@@ -622,11 +622,14 @@ class CachedUpdatePersister(ModelPersister):
         active_version = None
 
         if self.check_version:
-            active_version = self.list_properties()['active-model']
+            active_version = self.list_properties().get('active-model')
             if self._loaded_version == (active_version, args, kwargs):
                 return
 
-        model = self.impl.read(*args, **kwargs)
+        try:
+            model = self.impl.read(*args, **kwargs)
+        except LookupError:
+            model = None
         if model is not None:
             self.cache[self.__pld_config_key__] = model
 

--- a/palladium/tests/test_persistence.py
+++ b/palladium/tests/test_persistence.py
@@ -802,6 +802,13 @@ class TestCachedUpdatePersister:
         assert process_store['mypersister'] is impl.read.return_value
         assert impl.read.call_count == 1
 
+    def test_update_cache_lookup_error(self, persister, process_store):
+        persister.impl.read.side_effect = LookupError
+        persister.__pld_config_key__ = 'thypersister'
+        persister.check_version = False
+        assert persister.update_cache() is None
+        assert 'thypersister' not in process_store
+
     def test_dont_cache(self, process_store, CachedUpdatePersister, config):
         config['__mode__'] = 'fit'
 


### PR DESCRIPTION
The idea is to allow a server to be started up without a trained model, where the model is trained later on, for example with the new `/fit` and `/update-model-cache` endpoints (#71).

Steps to test this:

- Make sure you have no previously fitted model, or delete any.

- Add the following bit of configuration to `examples/iris/config.py`.  This is copied from the docs:

```
    'flask_add_url_rules': [
        {
            '__factory__': 'palladium.server.add_url_rule',
            'rule': '/fit',
            'view_func': 'palladium.server.fit',
            'methods': ['POST'],
        },
        {
            '__factory__': 'palladium.server.add_url_rule',
            'rule': '/update-model-cache',
            'view_func': 'palladium.server.update_model_cache',
            'methods': ['POST'],
        },
    ],
```

- Notice that trying to make a prediction at this point will fail: http://localhost:5000/predict?sepal%20length=6.3&sepal%20width=2.5&petal%20length=4.9&petal%20width=1.5

- Now send a POST request to the fit handler:

```
>>> import requests
>>> requests.post('http://localhost:5000/fit')
```

- At this point, the prediction will still not work.  Since the `CachedUpdatePersister` hasn't updated its cache yet.

- To force the `CachedUpdatePersister` to update, there's the `update-model-cache` endpoint:

```
>>> requests.post('http://localhost:5000/update-model-cache')
```

- Now you should be able to predict: http://localhost:5000/predict?sepal%20length=6.3&sepal%20width=2.5&petal%20length=4.9&petal%20width=1.5