### PR TITLE
/update-model-cache should be registered manually as per docs

### DIFF
--- a/palladium/server.py
+++ b/palladium/server.py
@@ -402,7 +402,6 @@ def fit():
     return make_ujson_response({'job_id': job_id}, status_code=200)
 
 
-@app.route('/update-model-cache', methods=['POST'])
 @PluggableDecorator('update_model_cache_decorators')
 @args_from_config
 def update_model_cache(model_persister):


### PR DESCRIPTION
We didn't want this view to be registered by default since it's easy
to bring down the service with it.  ;-)

Here's from the docs on how to register it manually:

    'flask_add_url_rules': [
        {
            '__factory__': 'palladium.server.add_url_rule',
            'rule': '/update-model-cache',
            'view_func': 'palladium.server.update_model_cache',
            'methods': ['POST'],
        },
    ]