### PR TITLE
Fix bad reuse of 'fit_decorators' identifier

### DIFF
--- a/palladium/server.py
+++ b/palladium/server.py
@@ -385,7 +385,7 @@ def list(model_persister):
     return make_ujson_response(info)
 
 
-@PluggableDecorator('fit_decorators')
+@PluggableDecorator('server_fit_decorators')
 @args_from_config
 def fit():
     param_converters = {


### PR DESCRIPTION
Very bad idea to have two completely different functions use the same
decorator name.