### PR TITLE
pld-export exports a model from one model persister to another

### DIFF
--- a/docs/user/scripts.rst
+++ b/docs/user/scripts.rst
@@ -62,6 +62,11 @@ pld-admin: *administer available models*
 
 .. autosimple:: palladium.fit.admin_cmd
 
+pld-export: *export a model from one persister to another*
+==========================================================
+
+.. autosimple:: palladium.util.export_cmd
+
 pld-version: *display version number*
 =====================================
 

--- a/palladium/tests/test_util.py
+++ b/palladium/tests/test_util.py
@@ -202,6 +202,31 @@ class TestUpgrade:
                                              to_version='0.2')
 
 
+class TestExport:
+    @pytest.fixture
+    def export(self):
+        from palladium.util import export
+        return export
+
+    def test_no_args(self, export):
+        persister = Mock()
+        persister_export = Mock()
+        export(persister, persister_export)
+        persister.read.assert_called_with(None)
+        persister_export.write.assert_called_with(persister.read())
+        persister_export.activate.assert_called_with(persister_export.write())
+
+    def test_model_version(self, export):
+        persister = Mock()
+        export(persister, Mock(), model_version=123)
+        persister.read.assert_called_with(123)
+
+    def test_activate(self, export):
+        persister_export = Mock()
+        export(Mock(), persister_export, activate=False)
+        assert persister_export.activate.call_count == 0
+
+
 def dec1(func):
     def inner(a, b):
         """dec1"""

--- a/palladium/util.py
+++ b/palladium/util.py
@@ -245,6 +245,47 @@ Options:
     upgrade(from_version=arguments['--from'], to_version=arguments['--to'])
 
 
+@args_from_config
+def export(
+    model_persister,
+    model_persister_export,
+    model_version=None,
+    activate=True,
+):
+    model = model_persister.read(model_version)
+    model_version_export = model_persister_export.write(model)
+    if activate:
+        model_persister_export.activate(model_version_export)
+    return model_version_export
+
+
+def export_cmd(argv=sys.argv[1:]):  # pragma: no cover
+    """\
+Export a model from one model persister to another.
+
+The model persister to export to is supposed to be available in the
+configuration file under the 'model_persister_export' key.
+
+Usage:
+  pld-export [options]
+
+Options:
+  --version=<v>            Export a specific version rather than the active
+                           one.
+
+  --no-activate            Don't activate the exported model with the
+                           'model_persister_export'.
+
+  -h --help                Show this screen.
+"""
+    arguments = docopt(export_cmd.__doc__, argv=argv)
+    model_version = export(
+        model_version=arguments['--version'],
+        activate=not arguments['--no-activate'],
+        )
+    logger.info("Exported model. New version number: {}".format(model_version))
+
+
 class PluggableDecorator:
     def __init__(self, decorator_config_name):
         self.decorator_config_name = decorator_config_name

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(name='palladium',
               'pld-test = palladium.eval:test_cmd',
               'pld-upgrade = palladium.util:upgrade_cmd',
               'pld-version = palladium.util:version_cmd',
+              'pld-export = palladium.util:export_cmd',
               ],
           'pytest11': [
               'palladium = palladium.tests',


### PR DESCRIPTION
The model persister to export to is supposed to be available in the
configuration file under the 'model_persister_export' key.

```
Usage:
  pld-export [options]

Options:
  --version=<v>            Export a specific version rather than the active
                           one.

  --no-activate            Don't activate the exported model with the
                           'model_persister_export'.
```