### PR TITLE
rpy2 now requires manual installation of tzlocal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda3/bin:$PATH
   - conda config --set always_yes yes --set changeps1 no
-  - conda install --yes -c r rpy2 r-randomforest
+  - conda install --yes -c r rpy2 r-randomforest tzlocal
   - conda install python=$TRAVIS_PYTHON_VERSION --file requirements.txt
   - conda update -q conda
   - pip install coveralls

--- a/docs/user/R.rst
+++ b/docs/user/R.rst
@@ -12,8 +12,9 @@ Palladium has support for using :class:`~palladium.interfaces.DatasetLoader` and
 :class:`~palladium.interfaces.Model` objects that are programmed in the R
 programming language.
 
-To use Palladium's R support, you'll have to install R and the Python `rpy2
-<https://pypi.python.org/pypi/rpy2>`_ package.
+To use Palladium's R support, you'll have to install R and the Python
+`rpy2 <https://pypi.python.org/pypi/rpy2>`_ package and `tzlocal
+<https://pypi.python.org/pypi/rpy2>`_.
 
 An example is available in the ``examples/R`` folder in the source
 tree of Palladium (:download:`config.py <../../examples/R/config.py>`,


### PR DESCRIPTION
R tests are broken on develop without this.