### PR TITLE
Add a few default locations for the Palladium config file

### DIFF
--- a/docs/user/configuration.rst
+++ b/docs/user/configuration.rst
@@ -15,7 +15,12 @@ Configuration files use Python syntax.  For an introduction, please
 visit the :ref:`tutorial`.
 
 Palladium uses an environment variable called ``PALLADIUM_CONFIG`` to
-look up the location of the configuration file.
+look up the location of one or more configuration files.  If
+``PALLADIUM_CONFIG`` is not set, Palladium will try to find a
+configuration file at these locations:
+
+- ``palladium-config.py``
+- ``etc/palladium-config.py``
 
 Variables
 =========

--- a/palladium/config.py
+++ b/palladium/config.py
@@ -12,6 +12,11 @@ PALLADIUM_CONFIG_ERROR = """
   refer to the manual for more details.
 """
 
+DEFAULT_CONFIG_FILE_LOCATIONS = (
+    'palladium-config.py',
+    os.path.join('etc', 'palladium-config.py'),
+    )
+
 
 class Config(dict):
     """A dictionary that represents the app's configuration.
@@ -212,7 +217,15 @@ def _get_config(**extra):
     if not _config.initialized:
         _config.update(extra)
         _config.initialized = True
+
         fnames = os.environ.get('PALLADIUM_CONFIG')
+        if fnames is None:
+            for fname in DEFAULT_CONFIG_FILE_LOCATIONS:
+                if os.path.exists(fname):  # pragma: no cover
+                    fnames = fname
+                    print("Using configuration at {}".format(fname))
+                    break
+
         if fnames is not None:
             configs = []
             fnames = [fname.strip() for fname in fnames.split(',')]

--- a/palladium/tests/test_persistence.py
+++ b/palladium/tests/test_persistence.py
@@ -76,7 +76,7 @@ class TestFile:
             patch('palladium.persistence.pickle.load') as load:
             lm.return_value = [{'version': 99}]
             lp.return_value = {'active-model': '99'}
-            exists.return_value = True
+            exists.side_effect = lambda fn: fn == '/models/model-99.pkl.gz'
             open.return_value = MagicMock()
             result = File('/models/model-{version}').read()
             open.assert_called_with('/models/model-99.pkl.gz', 'rb')
@@ -90,7 +90,7 @@ class TestFile:
             patch('palladium.persistence.gzip.open') as gzopen,\
             patch('palladium.persistence.pickle.load') as load:
             lm.return_value = [{'version': 99}]
-            exists.return_value = True
+            exists.side_effect = lambda fn: fn == '/models/model-432.pkl.gz'
             open.return_value = MagicMock()
             result = File('/models/model-{version}').read(432)
             open.assert_called_with('/models/model-432.pkl.gz', 'rb')


### PR DESCRIPTION
If ``PALLADIUM_CONFIG`` is not set, Palladium will try to find a
configuration file at these locations:

- ``palladium-config.py``
- ``etc/palladium-config.py``
- ``/etc/palladium-config.py``

I used `print()` rather than logging when a default config location is used because logging isn't set up at that point yet.