### PR TITLE
Fix issue with installing certifi on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ matrix:
 env:
   - TRAVIS=yes
 before_install:
-  - wget http://repo.continuum.io/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh -O miniconda.sh
+  - pip install -U pip && pip --version
+  - wget https://repo.anaconda.com/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda3/bin:$PATH
@@ -19,7 +20,10 @@ before_install:
   - conda install -q python=$TRAVIS_PYTHON_VERSION --file requirements.txt
   - conda update -q conda
   - pip install coveralls
-  - travis_retry python setup.py dev
+install:
+  - pip install -r requirements.txt
+  - pip install -e .
+  - python setup.py dev
 script:
   - travis_wait py.test --runslow
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,11 @@ before_install:
   - export PATH=/home/travis/miniconda3/bin:$PATH
   - conda config --set always_yes yes --set changeps1 no
   - conda install -q --yes -c r rpy2 r-randomforest tzlocal
-  - conda install -q python=$TRAVIS_PYTHON_VERSION --file requirements.txt
   - conda update -q conda
   - pip install coveralls
 install:
-  - pip install -r requirements.txt
-  - pip install -e .
-  - python setup.py dev
+  - conda install -q python=$TRAVIS_PYTHON_VERSION --file requirements.txt
+  - travis_retry python setup.py dev
 script:
   - travis_wait py.test --runslow
 deploy:


### PR DESCRIPTION
[Error](https://travis-ci.org/ottogroup/palladium/jobs/536222116) message:

```
Installing collected packages: certifi
  Found existing installation: certifi 2019.3.9
ERROR: Cannot uninstall 'certifi'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.
```

