### PR TITLE
display traceback when model is not found

### DIFF
--- a/palladium/persistence.py
+++ b/palladium/persistence.py
@@ -1,6 +1,6 @@
 """:class:`~palladium.interfaces.ModelPersister` implementations.
 """
-
+import logging
 from abc import abstractmethod
 import base64
 from contextlib import contextmanager
@@ -628,7 +628,8 @@ class CachedUpdatePersister(ModelPersister):
 
         try:
             model = self.impl.read(*args, **kwargs)
-        except LookupError:
+        except LookupError as ex:
+            logging.exception("Cannot find model version")
             model = None
         if model is not None:
             self.cache[self.__pld_config_key__] = model


### PR DESCRIPTION
The current version of Palladium loads models in the background and silently fails when the model isn't there or cannot be loaded, resulting in hard-to-trace error behaviour. With this, you at least get the information on where the model loading failed instead of (or rather in addition to) a mysterious KeyError that occurs when palladium tries to use the nonexistent model.