### PR TITLE
Introduce AWS S3 persister

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - conda install -q python=$TRAVIS_PYTHON_VERSION
   - pip install -r requirements.txt -r requirements-dev.txt
   - pip install pandas==0.23.4  # for rpy2 compatibility
-  - pip install -e .[docs,testing]
+  - pip install -e .[docs,testing,S3]
 script:
   - travis_wait py.test --runslow
 deploy:

--- a/palladium/tests/test_persistence.py
+++ b/palladium/tests/test_persistence.py
@@ -3,6 +3,7 @@ import gzip
 import json
 import os
 import pickle
+import posixpath
 from threading import Thread
 from unittest.mock import Mock
 from unittest.mock import MagicMock
@@ -853,3 +854,121 @@ class TestCachedUpdatePersister:
         persister = CachedUpdatePersister(impl)
         assert persister.upgrade("0.9", "1.0") is impl.upgrade.return_value
         impl.upgrade.assert_called_with("0.9", "1.0")
+
+
+class TestS3IO:
+    @pytest.fixture
+    def test_model_cls(self):
+        class TestModel:
+            def __init__(self, name, value):
+                self.name = name
+                self.value = str(value)
+        return TestModel
+
+    @pytest.fixture
+    def test_models(self, test_model_cls):
+        return [test_model_cls(f"model_{n}", n) for n in range(3)]
+
+    @pytest.fixture
+    def bucket_name(self):
+        return 'test-bucket'
+
+    @pytest.yield_fixture
+    def s3_io_filled(self, bucket_name, test_models, s3_io_cls):
+        import moto, boto3
+        with moto.mock_s3():
+            conn = boto3.resource('s3')
+            conn.create_bucket(Bucket=bucket_name)
+
+            s3 = boto3.client('s3')
+            for model in test_models:
+                s3.put_object(
+                    Bucket=bucket_name,
+                    Key=model.name,
+                    Body=model.value,
+                )
+
+            yield s3_io_cls()
+
+    @pytest.fixture
+    def s3_io_cls(self):
+        from palladium.persistence import S3IO
+        return S3IO
+
+    def test_open(self, s3_io_filled, test_models, bucket_name):
+        for expected_model in test_models:
+            obj = s3_io_filled.open(posixpath.join(
+                bucket_name,
+                expected_model.name,
+            ))
+
+            assert obj.read() == expected_model.value
+
+    def test_exists(self, s3_io_filled, test_models, bucket_name):
+        for expected_model in test_models:
+            assert s3_io_filled.exists(posixpath.join(
+                bucket_name,
+                expected_model.name,
+            ))
+
+    def test_remove(self, s3_io_filled, test_models, bucket_name):
+        s3_io_filled.remove(posixpath.join(
+            bucket_name,
+            test_models[0].name,
+        ))
+
+        assert not s3_io_filled.exists(posixpath.join(
+            bucket_name,
+            test_models[0].name,
+        ))
+
+        for expected_model in test_models[1:]:
+            assert s3_io_filled.exists(posixpath.join(
+                bucket_name,
+                expected_model.name,
+            ))
+
+
+
+class TestS3:
+    @pytest.fixture
+    def s3_cls(self):
+        from palladium.persistence import S3
+        return S3
+
+    @pytest.yield_fixture
+    def s3_cls_with_bucket(self, bucket_name, s3_cls):
+        import moto, boto3
+        with moto.mock_s3():
+            conn = boto3.resource('s3')
+            conn.create_bucket(Bucket=bucket_name)
+
+            yield s3_cls
+
+    @pytest.fixture
+    def bucket_name(self):
+        return 'test-bucket'
+
+    @pytest.fixture
+    def dummy_model(self):
+        return Dummy(weight=3)
+
+    def test_write_read(self, dummy_model, bucket_name, s3_cls_with_bucket):
+        persister = s3_cls_with_bucket(posixpath.join(
+            bucket_name,
+            'mymodel-{version}',
+        ))
+        persister.write(dummy_model)
+
+        assert persister.io.exists(posixpath.join(
+            bucket_name,
+            'mymodel-1.pkl.gz',
+        ))
+
+        assert persister.io.exists(posixpath.join(
+            bucket_name,
+            'mymodel-metadata.json',
+        ))
+
+        model = persister.read(version=1)
+        assert type(model) == type(dummy_model)

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(name='palladium',
           'docs': docs_require,
           'julia': ['julia'],
           'R': ['rpy2'],
+          'S3': ['s3fs', 'moto'],
           },
       entry_points={
           'console_scripts': [


### PR DESCRIPTION
This persister allows storing and loading models to and from AWS S3
buckets using s3fs to abstract the necessary API calls.

As discussed in https://github.com/ottogroup/palladium/issues/110#issuecomment-524975589 I have added the dependencies as extra dependencies and the imports are handled in the `S3IO` class.