### PR TITLE
Remove julia and rpy2 from docs extra requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ tests_require = [
     ]
 
 docs_require = [
-    'julia',
-    'rpy2',
+    # 'julia',
+    # 'rpy2',
     'Sphinx',
     'sphinx_rtd_theme',
     ]


### PR DESCRIPTION
An attempt to fix an issue on Travis where rpy2 is installed with
pip (in addition to conda) and appears to be buggy.