### PR TITLE
write meaningful error message

### DIFF
--- a/palladium/persistence.py
+++ b/palladium/persistence.py
@@ -183,7 +183,7 @@ class FileLike(ModelPersister):
         if version is None:
             props = self.list_properties()
             if 'active-model' not in props:
-                raise LookupError("No active model available")
+                raise LookupError("No active model available:"+self.path)
             version = props['active-model']
 
         fname = self.path.format(version=version) + '.pkl.gz'


### PR DESCRIPTION
In systems with multiple models and/or multiple model locations it's often not obvious which of the models / model locations is missing something. This gives a more meaningful error message.