### PR TITLE
avoid loading stale metadata in S3 persister

### DIFF
--- a/palladium/persistence.py
+++ b/palladium/persistence.py
@@ -712,6 +712,8 @@ class S3IO(FileLikeIO):
         self.fs = s3fs.S3FileSystem(anon=False)
 
     def open(self, path, mode='r'):
+        # this is needed to avoid reading stale metadata JSONs
+        self.fs.invalidate_cache()
         return self.fs.open(path, mode=mode)
 
     def exists(self, path):


### PR DESCRIPTION
This fixes a problem where putting a new model in the S3 bucket resulted in an invalid metadata JSON being read by the running palladium service. This is due to internal caching in s3fs, clearing the cache seems to fix the issue. (Hat tip to Aleksandra who found the fix).