### PR TITLE
palladium.cache: Fix bug with concurrent use of cache decorator

### DIFF
--- a/palladium/cache.py
+++ b/palladium/cache.py
@@ -9,6 +9,7 @@ import hashlib
 from functools import wraps
 import os
 import pickle
+from random import randrange
 from tempfile import gettempdir
 
 from joblib import numpy_pickle
@@ -109,7 +110,10 @@ class diskcache(abstractcache):
     def __setitem__(self, key, value):
         filename = self._filename(key)
         os.makedirs(os.path.dirname(filename), exist_ok=True)
-        return self.dump(value, filename)
+        filename_tmp = f'{filename}_tmp_{randrange(1_000_000)}'
+        val = self.dump(value, filename_tmp)
+        os.rename(filename_tmp, filename)
+        return val
 
 
 class picklediskcache(diskcache):


### PR DESCRIPTION
This introduces a temporary file to write to while we `pickle.dump` or `joblib.numpy_pickle.dump` which is then moved to the final destination using an atomic `os.rename`.  Previously, this would fail to due one thread _starting_ to write to the file, while another finds that the file already exists and starts to read from an incomplete file resulting in OSError and similar.