### PR TITLE
Be more defensive when assigning `__pld_config_key__`

### DIFF
--- a/palladium/config.py
+++ b/palladium/config.py
@@ -52,7 +52,7 @@ class ComponentHandler:
         component = factory(**specification)
         try:
             component.__pld_config_key__ = name
-        except AttributeError:
+        except (AttributeError, ValueError):
             pass
         self.components.append(component)
         return component


### PR DESCRIPTION
ValueError is raised in case component is a pydantic BaseModel.